### PR TITLE
Correcting Github undetected formatting problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog tracks changes of the qoqo_qiskit project starting at version 0.1.0 (initial release).
 
+### 0.1.3
+
+* Correcting Github release issues
+
 ### 0.1.2
 
 * Added support for PragmaLoop

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qiskit"
-version = "0.1.2"
+version = "0.1.3"
 license = {file="LICENSE"}
 authors = [
     {name="HQS Quantum Simulation GmbH", email="info@quantumsimulations.de"}

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
@@ -82,9 +82,7 @@ class QoqoQiskitBackend:
         output_complex_register_dict: Dict[str, List[List[complex]]] = dict()
 
         for bit_def in circuit.filter_by_tag("DefinitionBit"):
-            internal_bit_register_dict[bit_def.name()] = [
-                False for _ in range(bit_def.length())
-            ]
+            internal_bit_register_dict[bit_def.name()] = [False for _ in range(bit_def.length())]
             clas_regs_sizes[bit_def.name()] = bit_def.length()
             if bit_def.is_output():
                 output_bit_register_dict[bit_def.name()] = list()
@@ -94,9 +92,7 @@ class QoqoQiskitBackend:
                 0.0 for _ in range(float_def.length())
             ]
             if float_def.is_output():
-                output_float_register_dict[float_def.name()] = cast(
-                    List[List[float]], list()
-                )
+                output_float_register_dict[float_def.name()] = cast(List[List[float]], list())
 
         for complex_def in circuit.filter_by_tag("DefinitionComplex"):
             internal_complex_register_dict[complex_def.name()] = [


### PR DESCRIPTION
The latest PR did not run the checks successfully and was wrongfully merged. This solves the undetected errors.