### PR TITLE
Dep Update, Python 3.12 Support, Devices Deprecation

### DIFF
--- a/.github/workflows/hqs-build-deploy-rust-pyo3.yml
+++ b/.github/workflows/hqs-build-deploy-rust-pyo3.yml
@@ -52,7 +52,6 @@ jobs:
       # Try to build python wheels with universal2 for arm and x86
       universal2: true
       deploy: true
-      python_3_12: false
     secrets: inherit
 
 # Build windows wheels and upload them to PyPi

--- a/.github/workflows/hqs-ci-test-pure-python.yml
+++ b/.github/workflows/hqs-ci-test-pure-python.yml
@@ -22,4 +22,3 @@ jobs:
       windows: false
       # Run tests also on macos runners
       macos: true
-      python_3_12: false

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -19,7 +19,6 @@ jobs:
       # Test code coverage of rust core is over 90 percent
       test_code_coverage: true
       rust_package_name: "roqoqo_qiskit_devices"
-      python_3_12: false
 
   build_tests:
     uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@main
@@ -30,4 +29,3 @@ jobs:
       macos: false
       py_interface_folder: "qoqo_qiskit_devices"
       has_python_tests: true
-      python_3_12: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog tracks changes of the qoqo_qiskit project starting at version 0.1.0 (initial release).
 
+### 0.2.3
+
+* Updated to qoqo 1.9
+* Added support for Python 3.12
+* Pinned qiskit dependency to <=0.45
+
 ### 0.2.2
 
 * Updated qoqo_qiskit_devices `get_decoherence_on_gate_model` method docstring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog tracks changes of the qoqo_qiskit project starting at version 0.1
 
 * Updated to qoqo 1.9
 * Added support for Python 3.12
-* Pinned qiskit dependency to <=0.45
+* Pinned qiskit dependency to <0.46
 * Added deprecation warnings for retired devices (Lagos, Nairobi, Perth)
 
 ### 0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog tracks changes of the qoqo_qiskit project starting at version 0.1
 * Updated to qoqo 1.9
 * Added support for Python 3.12
 * Pinned qiskit dependency to <=0.45
+* Added deprecation warnings for retired devices (Lagos, Nairobi, Perth)
 
 ### 0.2.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
 
 [[package]]
 name = "cfg-if"
@@ -93,9 +93,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -109,15 +109,15 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inventory"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -130,9 +130,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
  "serde",
@@ -321,9 +321,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_qiskit_devices"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bincode",
  "ndarray",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo_qiskit_devices"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ndarray",
  "roqoqo",
@@ -635,18 +635,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -690,15 +690,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "struqture"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b3b736950a60ff795d13e8e89d75fde0bd9510ea420f06c0649791f6fe3194"
+checksum = "be0c8e01ccb1eb5704756651126b09a0eb276fe3d018e87f6490773cefb38359"
 dependencies = [
  "itertools",
  "ndarray",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592b7232573f8d40afc2f55d6829a45a31e0bb3d371e4930f4470400fa62d352"
+checksum = "09b138454a27864ea7ca9a22eaf0351270c78cb329961e5d46395cc9bcac31b3"
 dependencies = [
  "bincode",
  "num-complex",
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py-macros"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3abb53a16639536f41a39adf11db2ed2f318217de87fc4f47c1caf771d7576"
+checksum = "9274be85d19e94e55fba30b59ef862d2b11778b099a61449cb381c8965644c79"
 dependencies = [
  "num-complex",
  "proc-macro2",
@@ -870,9 +870,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
+checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     'darglint',
     'bandit',
     'mypy',
-    'black<24',
+    'black',
     'ruff',
 ]
 docs = [

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
     "qoqo>=1.9",
     "qoqo_qasm>=0.9.2",
-    "qiskit<=0.45",
+    "qiskit<0.46",
     "qiskit_aer",
     "numpy"
 ]

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     'darglint',
     'bandit',
     'mypy',
-    'black',
+    'black<24',
     'ruff',
 ]
 docs = [

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "qoqo_qiskit"
 version = "0.2.3"
-license = {file="LICENSE"}
+license = { file = "LICENSE" }
 authors = [
-    {name="HQS Quantum Simulation GmbH", email="info@quantumsimulations.de"}
+    { name = "HQS Quantum Simulation GmbH", email = "info@quantumsimulations.de" },
 ]
 maintainers = [
-    {name="Matteo Lodi", email="matteo.lodi@quantumsimulations.de"}
+    { name = "Matteo Lodi", email = "matteo.lodi@quantumsimulations.de" },
 ]
 readme = "README.md"
 requires-python = ">=3.8"
@@ -14,16 +14,12 @@ dependencies = [
     "qoqo>=1.9",
     "qoqo_qasm>=0.9.2",
     "qiskit<0.46",
-    "qiskit_aer",
-    "numpy"
+    "qiskit_aer>=0.13.2",
+    "numpy",
 ]
 
 [project.optional-dependencies]
-tests = [
-  'pytest',
-  'pytest-cov',
-  'coverage'
-]
+tests = ['pytest', 'pytest-cov', 'coverage']
 dev = [
     'flake8',
     'flake8-bugbear',
@@ -42,7 +38,7 @@ docs = [
     'recommonmark',
     'myst_parser',
     'sphinx_rtd_theme',
-    'tomli'
+    'tomli',
 ]
 
 [build-system]
@@ -61,34 +57,34 @@ target-version = ["py39", "py310", "py311"]
 [tool.coverage.run]
 branch = true
 omit = ["tests/*", "*test*.py"]
-source=["qoqo_qiskit"]
+source = ["qoqo_qiskit"]
 
 [tool.coverage.paths]
 source = ["src", "**/site-packages"]
 
 [tool.ruff]
-line-length = 99  # same as black
+line-length = 99        # same as black
 target-version = "py39"
 show-fixes = true
 show-source = true
 # activate the following checks
 select = [
-    "A",  # builtins
-    "ANN",  # annotations
-    "ARG",  # unused arguments
-    "B",  # bugbear
-    "C",  # comprehensions
-    "C90",  # mccabe complexity
-    "D",  # pydocstyle
-    "E",  # pycodestyle
-    "ERA",  # remove commented out code
-    "F",  # pyflakes
-    "NPY",  # numpy
+    "A",   # builtins
+    "ANN", # annotations
+    "ARG", # unused arguments
+    "B",   # bugbear
+    "C",   # comprehensions
+    "C90", # mccabe complexity
+    "D",   # pydocstyle
+    "E",   # pycodestyle
+    "ERA", # remove commented out code
+    "F",   # pyflakes
+    "NPY", # numpy
     "PL",  # pylint
-    "RUF",  # ruff
-    "S",  # bandit
-    "TCH",  # type checking
-    "W",  # Warnings
+    "RUF", # ruff
+    "S",   # bandit
+    "TCH", # type checking
+    "W",   # Warnings
 ]
 # ignore specific violations
 ignore = [
@@ -106,10 +102,50 @@ ignore = [
 ]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = [
-    "A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W",
-    "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT",
-    "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI",
-    "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "I",
+    "N",
+    "Q",
+    "S",
+    "T",
+    "W",
+    "ANN",
+    "ARG",
+    "BLE",
+    "COM",
+    "DJ",
+    "DTZ",
+    "EM",
+    "ERA",
+    "EXE",
+    "FBT",
+    "ICN",
+    "INP",
+    "ISC",
+    "NPY",
+    "PD",
+    "PGH",
+    "PIE",
+    "PL",
+    "PT",
+    "PTH",
+    "PYI",
+    "RET",
+    "RSE",
+    "RUF",
+    "SIM",
+    "SLF",
+    "TCH",
+    "TID",
+    "TRY",
+    "UP",
+    "YTT",
 ]
 unfixable = []
 # exclude the following patterns from linting
@@ -120,11 +156,11 @@ exclude = [
     "old",
     "build",
     "dist",
-    "test_*"
+    "test_*",
 ]
 
 [tool.ruff.mccabe]
-max-complexity = 20  # 5 higher than sonarqube
+max-complexity = 20 # 5 higher than sonarqube
 
 [tool.ruff.pydocstyle]
 convention = "google"
@@ -133,9 +169,9 @@ convention = "google"
 "__init__.py" = ["F401"]
 
 [tool.flake8]
-max-line-length = 99  # same as black
+max-line-length = 99 # same as black
 ignore = [
-    "E203",  # Needed for compatibility with black
+    "E203",   # Needed for compatibility with black
     "D400",
     "D401",
     "W503",
@@ -158,6 +194,4 @@ exclude = [
     "test_*",
 ]
 docstring-convention = "google"
-per-file-ignores = [
-    "__init__.py:F401",
-]
+per-file-ignores = ["__init__.py:F401"]

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qiskit"
-version = "0.2.2"
+version = "0.2.3"
 license = {file="LICENSE"}
 authors = [
     {name="HQS Quantum Simulation GmbH", email="info@quantumsimulations.de"}
@@ -9,11 +9,11 @@ maintainers = [
     {name="Matteo Lodi", email="matteo.lodi@quantumsimulations.de"}
 ]
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 dependencies = [
-    "qoqo>=1.8",
+    "qoqo>=1.9",
     "qoqo_qasm>=0.9.2",
-    "qiskit",
+    "qiskit<=0.45",
     "qiskit_aer",
     "numpy"
 ]

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
@@ -49,7 +49,8 @@ class QoqoQiskitBackend:
         self.compilation = compilation
 
     def run_circuit(
-        self, circuit: Circuit
+        self,
+        circuit: Circuit,
     ) -> Tuple[
         Dict[str, List[List[bool]]],
         Dict[str, List[List[float]]],
@@ -175,7 +176,8 @@ class QoqoQiskitBackend:
         )
 
     def run_measurement_registers(
-        self, measurement: Any
+        self,
+        measurement: Any,
     ) -> Tuple[
         Dict[str, List[List[bool]]],
         Dict[str, List[List[float]]],
@@ -285,7 +287,8 @@ class QoqoQiskitBackend:
         return splitted
 
     def _setup_registers(
-        self, circuit: Circuit
+        self,
+        circuit: Circuit,
     ) -> Tuple[
         Dict[str, int],
         Dict[str, List[List[bool]]],

--- a/qoqo_qiskit_devices/Cargo.toml
+++ b/qoqo_qiskit_devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qiskit_devices"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -18,9 +18,9 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-qoqo = { version = "1.8", default-features=false}
-roqoqo = "1.8"
-qoqo-macros = "1.8"
+qoqo = { version = "1.9", default-features=false}
+roqoqo = "1.9"
+qoqo-macros = "1.9"
 
 ndarray = "0.15"
 bincode = "1.3"

--- a/qoqo_qiskit_devices/pyproject.toml
+++ b/qoqo_qiskit_devices/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.2.3"
 dependencies = [
   'qoqo_calculator_pyo3>=1.1',
   'qoqo>=1.9',
+  'qiskit<0.46',
   'qiskit-ibm-provider',
   'struqture_py',
 ]

--- a/qoqo_qiskit_devices/pyproject.toml
+++ b/qoqo_qiskit_devices/pyproject.toml
@@ -7,21 +7,24 @@ dependencies = [
   'qiskit<0.46',
   'qiskit-ibm-provider',
   'struqture_py',
+  'setuptools; python_version>=3.12',
 ]
-license = {text="Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause"}
-maintainers = [{name = "HQS Quantum Simulations GmbH", email = "info@quantumsimulations.de"}]
+license = { text = "Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause" }
+maintainers = [
+  { name = "HQS Quantum Simulations GmbH", email = "info@quantumsimulations.de" },
+]
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
 docs = [
-    'numpy',
-    'sphinx>=2.1',
-    'nbsphinx',
-    'pygments',
-    'recommonmark',
-    'myst_parser',
-    'sphinx_rtd_theme',
-    'tomli'
+  'numpy',
+  'sphinx>=2.1',
+  'nbsphinx',
+  'pygments',
+  'recommonmark',
+  'myst_parser',
+  'sphinx_rtd_theme',
+  'tomli',
 ]
 
 [build-system]

--- a/qoqo_qiskit_devices/pyproject.toml
+++ b/qoqo_qiskit_devices/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "qoqo_qiskit_devices"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
   'qoqo_calculator_pyo3>=1.1',
-  'qoqo>=1.8',
+  'qoqo>=1.9',
   'qiskit-ibm-provider',
   'struqture_py',
 ]

--- a/qoqo_qiskit_devices/pyproject.toml
+++ b/qoqo_qiskit_devices/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
   'qiskit<0.46',
   'qiskit-ibm-provider',
   'struqture_py',
-  'setuptools; python_version>=3.12',
+  "setuptools; python_version>='3.12'",
 ]
 license = { text = "Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause" }
 maintainers = [

--- a/qoqo_qiskit_devices/python_tests/test_initialization.py
+++ b/qoqo_qiskit_devices/python_tests/test_initialization.py
@@ -40,7 +40,12 @@ def test_jakarta():
 
 def test_lagos():
     """Test IBMLagosDevice initialization."""
-    ibm_devices.IBMLagosDevice()
+    with warnings.catch_warnings(record=True) as w:
+        dev = ibm_devices.IBMLagosDevice()
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "retired" in str(w[-1].message)
+        assert dev.name() in str(w[-1].message)
 
 
 def test_lima():
@@ -65,12 +70,22 @@ def test_manila():
 
 def test_nairobi():
     """Test IBMNairobiDevice initialization."""
-    ibm_devices.IBMNairobiDevice()
+    with warnings.catch_warnings(record=True) as w:
+        dev = ibm_devices.IBMNairobiDevice()
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "retired" in str(w[-1].message)
+        assert dev.name() in str(w[-1].message)
 
 
 def test_perth():
     """Test IBMPerthDevice initialization."""
-    ibm_devices.IBMPerthDevice()
+    with warnings.catch_warnings(record=True) as w:
+        dev = ibm_devices.IBMPerthDevice()
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "retired" in str(w[-1].message)
+        assert dev.name() in str(w[-1].message)
 
 
 def test_quito():

--- a/qoqo_qiskit_devices/python_tests/test_qiskit_info_retrieval.py
+++ b/qoqo_qiskit_devices/python_tests/test_qiskit_info_retrieval.py
@@ -29,8 +29,8 @@ def test_info_update():
 
     assert belem.single_qubit_gate_time("PauliX", 0) == 1.0
     assert belem.two_qubit_gate_time("CNOT", 0, 1) == 1.0
-    assert belem.three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2) == None
-    assert belem.multi_qubit_gate_time("MultiQubitMS", [0, 1, 2, 3]) == None
+    assert belem.three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2) is None
+    assert belem.multi_qubit_gate_time("MultiQubitMS", [0, 1, 2, 3]) is None
     assert np.all(belem.qubit_decoherence_rates(0) == 0.0)
 
     with warnings.catch_warnings(record=True) as w:
@@ -42,9 +42,9 @@ def test_info_update():
         assert belem.single_qubit_gate_time("PauliX", 0) != 1.0
         assert belem.two_qubit_gate_time("CNOT", 0, 1) != 1.0
         assert (
-            belem.three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2) == None
+            belem.three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2) is None
         )
-        assert belem.multi_qubit_gate_time("MultiQubitMS", [0, 1, 2, 3]) == None
+        assert belem.multi_qubit_gate_time("MultiQubitMS", [0, 1, 2, 3]) is None
         assert np.any(belem.qubit_decoherence_rates(0) != 0.0)
 
 

--- a/qoqo_qiskit_devices/qoqo_qiskit_devices/DEPENDENCIES
+++ b/qoqo_qiskit_devices/qoqo_qiskit_devices/DEPENDENCIES
@@ -727,7 +727,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-bytemuck 1.14.0
+bytemuck 1.14.2
 https://github.com/Lokathor/bytemuck
 by Lokathor <zefria@gmail.com>
 A crate for mucking around with piles of bytes.
@@ -2733,8 +2733,8 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-indexmap 2.1.0
-https://github.com/bluss/indexmap
+indexmap 2.2.2
+https://github.com/indexmap-rs/indexmap
 by 
 A hash table with consistent order and fast iteration.
 License: Apache-2.0 OR MIT
@@ -3188,7 +3188,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-inventory 0.3.14
+inventory 0.3.15
 https://github.com/dtolnay/inventory
 by David Tolnay <dtolnay@gmail.com>
 Typed distributed plugin registration
@@ -3402,7 +3402,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-itertools 0.12.0
+itertools 0.12.1
 https://github.com/rust-itertools/itertools
 by bluss
 Extra iterator adaptors, iterator methods, free functions, and macros.
@@ -3857,7 +3857,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libc 0.2.152
+libc 0.2.153
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -5292,7 +5292,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-num-complex 0.4.4
+num-complex 0.4.5
 https://github.com/rust-num/num-complex
 by The Rust Project Developers
 Complex numbers implementation for Rust
@@ -7709,7 +7709,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-proc-macro2 1.0.76
+proc-macro2 1.0.78
 https://github.com/dtolnay/proc-macro2
 by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.
@@ -9915,7 +9915,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_qiskit_devices 0.2.2
+qoqo_qiskit_devices 0.2.3
 https://github.com/HQSquantumsimulations/qoqo_qiskit
 by HQS Quantum Simulations <info@quantumsimulations.de>
 IBM's Qiskit devices interface for qoqo python quantum computing toolkit
@@ -11960,7 +11960,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo_qiskit_devices 0.2.2
+roqoqo_qiskit_devices 0.2.3
 https://github.com/HQSquantumsimulations/qoqo_qiskit
 by HQS Quantum Simulations <info@quantumsimulations.de>
 IBM's Qiskit devices interface for roqoqo rust quantum computing toolkit
@@ -13035,7 +13035,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde 1.0.195
+serde 1.0.196
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -13249,7 +13249,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.195
+serde_derive 1.0.196
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -13702,7 +13702,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_json 1.0.111
+serde_json 1.0.113
 https://github.com/serde-rs/json
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A JSON serialization file format
@@ -14128,7 +14128,7 @@ LICENSE:
 
 
 ====================================================
-smallvec 1.11.2
+smallvec 1.13.1
 https://github.com/servo/rust-smallvec
 by The Servo Project Developers
 'Small vector' optimization: store up to a small number of items on the stack
@@ -14369,7 +14369,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-struqture 1.5.2
+struqture 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
@@ -14580,13 +14580,13 @@ LICENSE:
 
 
 ====================================================
-struqture-py 1.5.2
+struqture-py 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of struqture, the HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
 
 ====================================================
-struqture-py-macros 1.5.2
+struqture-py-macros 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for struqture-py crate.
 License: Apache-2.0
@@ -17688,7 +17688,7 @@ Software.
 
 
 ====================================================
-wide 0.7.13
+wide 0.7.15
 https://github.com/Lokathor/wide
 by Lokathor <zefria@gmail.com>
 A crate to help you go wide.

--- a/qoqo_qiskit_devices/qoqo_qiskit_devices/mocked_properties.py
+++ b/qoqo_qiskit_devices/qoqo_qiskit_devices/mocked_properties.py
@@ -68,4 +68,4 @@ class MockedProperties:
         Returns:
             float: T2 mocked time.
         """
-        return 0.00012
+        return 0.00048

--- a/qoqo_qiskit_devices/qoqo_qiskit_devices/mocked_properties.py
+++ b/qoqo_qiskit_devices/qoqo_qiskit_devices/mocked_properties.py
@@ -34,7 +34,7 @@ class MockedProperties:
         Returns:
             float: Gate property mocked time.
         """
-        return (50.0, 0)
+        return (0.00000005, 0)
 
     def gate_error(self, gate: str, qubits: Union[int, List[int]]) -> float:
         """Mocked gate error.
@@ -57,7 +57,7 @@ class MockedProperties:
         Returns:
             float: T1 mocked time.
         """
-        return 100.0
+        return 0.00012
 
     def t2(self, qubit: int) -> float:
         """T2 mocked time.
@@ -68,4 +68,4 @@ class MockedProperties:
         Returns:
             float: T2 mocked time.
         """
-        return 400.0
+        return 0.00012

--- a/qoqo_qiskit_devices/src/devices/ibm_lagos.rs
+++ b/qoqo_qiskit_devices/src/devices/ibm_lagos.rs
@@ -35,6 +35,9 @@ impl IBMLagosDeviceWrapper {
     /// Create a new IBMLagosDevice instance.
     #[new]
     pub fn new() -> Self {
+        Python::with_gil(|py| {
+            py.run("import warnings; warnings.warn(\"Device ibm_lagos has been retired. Setting noise information is not possible.\", category=DeprecationWarning, stacklevel=2)", None, None).unwrap();
+        });
         Self {
             internal: IBMLagosDevice::new(),
         }

--- a/qoqo_qiskit_devices/src/devices/ibm_nairobi.rs
+++ b/qoqo_qiskit_devices/src/devices/ibm_nairobi.rs
@@ -35,6 +35,9 @@ impl IBMNairobiDeviceWrapper {
     /// Create a new IBMNairobiDevice instance.
     #[new]
     pub fn new() -> Self {
+        Python::with_gil(|py| {
+            py.run("import warnings; warnings.warn(\"Device ibm_nairobi has been retired. Setting noise information is not possible.\", category=DeprecationWarning, stacklevel=2)", None, None).unwrap();
+        });
         Self {
             internal: IBMNairobiDevice::new(),
         }

--- a/qoqo_qiskit_devices/src/devices/ibm_perth.rs
+++ b/qoqo_qiskit_devices/src/devices/ibm_perth.rs
@@ -35,6 +35,9 @@ impl IBMPerthDeviceWrapper {
     /// Create a new IBMPerthDevice instance.
     #[new]
     pub fn new() -> Self {
+        Python::with_gil(|py| {
+            py.run("import warnings; warnings.warn(\"Device ibm_perth has been retired. Setting noise information is not possible.\", category=DeprecationWarning, stacklevel=2)", None, None).unwrap();
+        });
         Self {
             internal: IBMPerthDevice::new(),
         }

--- a/qoqo_qiskit_devices/tests/integration/main.rs
+++ b/qoqo_qiskit_devices/tests/integration/main.rs
@@ -13,4 +13,3 @@
 #[allow(deprecated)]
 #[cfg(test)]
 mod device;
-pub use device::*;

--- a/roqoqo_qiskit_devices/Cargo.toml
+++ b/roqoqo_qiskit_devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo_qiskit_devices"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -18,7 +18,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roqoqo = {version = "1.8", features = ["unstable_qoqo_devices"]}
+roqoqo = {version = "1.9", features = ["unstable_qoqo_devices"]}
 ndarray = "0.15"
 
 serde = {version = "1.0", features = ["derive"]}

--- a/roqoqo_qiskit_devices/tests/integration/main.rs
+++ b/roqoqo_qiskit_devices/tests/integration/main.rs
@@ -13,4 +13,3 @@
 #[allow(deprecated)]
 #[cfg(test)]
 mod device;
-pub use device::*;


### PR DESCRIPTION
* Updated to qoqo 1.9
* Added support for Python 3.12
* Pinned qiskit dependency to <0.46
* Added deprecation warnings for retired devices (Lagos, Nairobi, Perth)