### PR TITLE
Fixed `InputBit` Support + `.run_program()` Single Parameters List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This changelog tracks changes of the qoqo_qiskit project starting at version 0.1.0 (initial release).
 
+### 0.8.1
+
+* Fixed `.run_program()` allowing it to run with a single list of parameters
+* Fixed support for `InputBit` operation by keeping track of it and correct the circuit result in post-process
+
 ### 0.8.0
 
 * Updated to qiskit 1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_qiskit_devices"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bincode",
  "ndarray",
@@ -562,9 +562,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags",
 ]
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo_qiskit_devices"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ndarray",
  "roqoqo",
@@ -696,18 +696,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -904,9 +904,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unindent"

--- a/qoqo_qiskit/pyproject.toml
+++ b/qoqo_qiskit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qiskit"
-version = "0.8.0"
+version = "0.8.1"
 license = { file = "LICENSE" }
 authors = [
     { name = "HQS Quantum Simulation GmbH", email = "info@quantumsimulations.de" },

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
@@ -58,11 +58,7 @@ class QoqoQiskitBackend:
         self.compilation = compilation
 
     # Internal _run_circuit method
-    def _run_circuit(self, circuit: Circuit) -> Tuple[
-        Job,
-        str,
-        RegistersWithLengths,
-    ]:
+    def _run_circuit(self, circuit: Circuit) -> Tuple[Job, str, RegistersWithLengths, Circuit]:
         if not circuit.__class__.__name__ == "Circuit":
             raise TypeError("The input is not a valid Qoqo Circuit instance.")
 
@@ -129,15 +125,17 @@ class QoqoQiskitBackend:
         output_registers = RegistersWithLengths()
 
         for bit_def in circuit.filter_by_tag("DefinitionBit"):
-            output_registers.clas_regs_lengths[bit_def.name()] = bit_def.length()
+            output_registers.bit_regs_lengths[bit_def.name()] = bit_def.length()
             if bit_def.is_output():
                 output_registers.registers.bit_register_dict[bit_def.name()] = []
         for float_def in circuit.filter_by_tag("DefinitionFloat"):
+            output_registers.float_regs_lengths[float_def.name()] = float_def.length()
             if float_def.is_output():
                 output_registers.registers.float_register_dict[float_def.name()] = cast(
                     List[List[float]], []
                 )
         for complex_def in circuit.filter_by_tag("DefinitionComplex"):
+            output_registers.complex_regs_lengths[complex_def.name()] = complex_def.length()
             if complex_def.is_output():
                 output_registers.registers.complex_register_dict[complex_def.name()] = cast(
                     List[List[complex]], []

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
@@ -575,7 +575,8 @@ class QoqoQiskitBackend:
                     " input parameter names."
                 )
             queued_runs.append(self.run_measurement_queued(program.measurement()))
-        if isinstance(params_values[0], list):
+        elif isinstance(params_values[0], list):
+            params_values = cast(List[List[float]], params_values)
             for params in params_values:
                 if len(params) != len(input_parameter_names):
                     raise ValueError(

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/backend.py
@@ -58,13 +58,15 @@ class QoqoQiskitBackend:
         self.compilation = compilation
 
     # Internal _run_circuit method
-    def _run_circuit(self, circuit: Circuit) -> Tuple[Job, str, RegistersWithLengths, Circuit]:
+    def _run_circuit(
+        self, circuit: Circuit
+    ) -> Tuple[Job, str, RegistersWithLengths, Optional[Circuit]]:
         if not circuit.__class__.__name__ == "Circuit":
             raise TypeError("The input is not a valid Qoqo Circuit instance.")
 
         output_registers = self._set_up_registers(circuit)
 
-        (compiled_circuit, run_options) = self._compile_circuit(circuit)
+        (compiled_circuit, run_options, input_bit_circuit) = self._compile_circuit(circuit)
 
         self._handle_errors(run_options)
 
@@ -72,24 +74,25 @@ class QoqoQiskitBackend:
 
         job = self._job_execution(compiled_circuit, shots)
 
-        return (job, sim_type, output_registers)
+        return (job, sim_type, output_registers, input_bit_circuit)
 
     def _run_circuit_list(
         self, circuit_list: List[Circuit]
-    ) -> Tuple[Job, str, List[RegistersWithLengths]]:
+    ) -> Tuple[Job, str, List[RegistersWithLengths], List[Optional[Circuit]]]:
         if not isinstance(circuit_list, List):
             raise TypeError("The input is not a valid list of Qoqo Circuit instances.")
         if len(circuit_list) == 0:
             raise ValueError("The input is an empty list of Qoqo Circuit instances.")
 
         compiled_circuits_list: List[Circuit] = []
+        input_bit_circuits_list: List[Optional[Circuit]] = []
         output_registers_list: List[RegistersWithLengths] = []
         sim_type_list: Optional[str] = None
         shots_list: Optional[int] = None
         for circuit in circuit_list:
             output_registers = self._set_up_registers(circuit)
 
-            (compiled_circuit, run_options) = self._compile_circuit(circuit)
+            (compiled_circuit, run_options, input_bit_circuit) = self._compile_circuit(circuit)
 
             self._handle_errors(run_options)
 
@@ -112,11 +115,12 @@ class QoqoQiskitBackend:
                     )
 
             compiled_circuits_list.append(compiled_circuit)
+            input_bit_circuits_list.append(input_bit_circuit)
             output_registers_list.append(output_registers)
 
         job = self._job_execution(compiled_circuits_list, cast(int, shots_list))
 
-        return (job, cast(str, sim_type_list), output_registers_list)
+        return (job, cast(str, sim_type_list), output_registers_list, input_bit_circuits_list)
 
     def _set_up_registers(
         self,
@@ -145,7 +149,18 @@ class QoqoQiskitBackend:
     def _compile_circuit(
         self,
         circuit: Circuit,
-    ) -> Tuple[QuantumCircuit, Dict[str, Any]]:
+    ) -> Tuple[QuantumCircuit, Dict[str, Any], Optional[Circuit]]:
+        input_bit_circuit = Circuit()
+        tmp_circuit = Circuit()
+        for c in circuit:
+            if c.hqslang() == "InputBit":
+                input_bit_circuit += c
+            else:
+                tmp_circuit += c
+        if len(input_bit_circuit) == 0:
+            input_bit_circuit = None
+        circuit = tmp_circuit
+
         try:
             defs = circuit.definitions()
             doubles = [defs[0]]
@@ -166,7 +181,7 @@ class QoqoQiskitBackend:
         compiled_circuit: QuantumCircuit = res[0]
         run_options: Dict[str, Any] = res[1]
 
-        return compiled_circuit, run_options
+        return compiled_circuit, run_options, input_bit_circuit
 
     def _handle_errors(
         self,
@@ -257,7 +272,7 @@ class QoqoQiskitBackend:
         Raises:
             ValueError: Incorrect Measurement or Pragma operations.
         """
-        (job, sim_type, output_registers) = self._run_circuit(circuit)
+        (job, sim_type, output_registers, input_bit_circuit) = self._run_circuit(circuit)
 
         result = job.result()
 
@@ -267,6 +282,7 @@ class QoqoQiskitBackend:
             sim_type,
             result,
             output_registers,
+            input_bit_circuit,
         )
 
     def run_circuit_list(
@@ -297,7 +313,9 @@ class QoqoQiskitBackend:
             ValueError: Incorrect Measurement or Pragma operations or incompatible run options\
                 between different circuits.
         """
-        (job, sim_type, output_registers_list) = self._run_circuit_list(circuits)
+        (job, sim_type, output_registers_list, input_bit_circuits_list) = self._run_circuit_list(
+            circuits
+        )
 
         result = job.result()
 
@@ -307,6 +325,7 @@ class QoqoQiskitBackend:
             sim_type,
             result,
             output_registers_list,
+            input_bit_circuits_list,
         )
 
     def run_circuit_queued(
@@ -327,11 +346,7 @@ class QoqoQiskitBackend:
         Returns:
             QueuedCircuitRun
         """
-        (
-            job,
-            sim_type,
-            output_registers,
-        ) = self._run_circuit(circuit)
+        (job, sim_type, output_registers, _input_bit_circuit) = self._run_circuit(circuit)
 
         return QueuedCircuitRun(job, self.memory, sim_type, output_registers.to_flat_tuple())
 
@@ -354,6 +369,7 @@ class QoqoQiskitBackend:
             job,
             sim_type,
             output_registers,
+            _input_bit_circuits_list,
         ) = self._run_circuit_list(circuits)
 
         return [

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
@@ -22,16 +22,16 @@ from ..models import RegistersWithLengths
 
 
 def _counts_to_registers(
-    counts: Any, mem: bool, clas_regs_lengths: Dict[str, int]
+    counts: Any, mem: bool, bit_regs_lengths: Dict[str, int]
 ) -> List[List[List[bool]]]:
     bit_map: List[List[List[bool]]] = []
     reg_num = 0
-    for key in clas_regs_lengths:
-        reg_num += clas_regs_lengths[key]
+    for key in bit_regs_lengths:
+        reg_num += bit_regs_lengths[key]
     for _ in range(reg_num):
         bit_map.append([])
     for key in counts:
-        splitted = _split(key, clas_regs_lengths)
+        splitted = _split(key, bit_regs_lengths)
         for i, measurement in enumerate(splitted):
             transf_measurement = _bit_to_bool(measurement)
             if mem:
@@ -56,17 +56,17 @@ def _bit_to_bool(element: str) -> List[bool]:
     return ret
 
 
-def _split(element: str, clas_regs_lengths: Dict[str, int]) -> List[str]:
+def _split(element: str, bit_regs_lengths: Dict[str, int]) -> List[str]:
     splitted: list[str] = []
     if " " in element:
         splitted = element.split()
         splitted.reverse()
     else:
         element = element[::-1]
-        for key in clas_regs_lengths:
-            splitted.append(element[: clas_regs_lengths[key] :])
+        for key in bit_regs_lengths:
+            splitted.append(element[: bit_regs_lengths[key] :])
             splitted[-1] = splitted[-1][::-1]
-            element = element[clas_regs_lengths[key] :]
+            element = element[bit_regs_lengths[key] :]
     return splitted
 
 
@@ -83,7 +83,7 @@ def _transform_job_result_single(
         transformed_counts = _counts_to_registers(
             result.get_memory(res_index) if memory else result.get_counts(res_index),
             memory,
-            output_registers.clas_regs_lengths,
+            output_registers.bit_regs_lengths,
         )
         for i, reg in enumerate(output_registers.registers.bit_register_dict):
             output_registers.registers.bit_register_dict[reg] = [
@@ -108,7 +108,7 @@ def _transform_job_result_list(
     if sim_type == "automatic":
         res_list = result.get_memory() if memory else result.get_counts()
         for res, regs in zip(res_list, output_registers):
-            transformed_counts = _counts_to_registers(res, memory, regs.clas_regs_lengths)
+            transformed_counts = _counts_to_registers(res, memory, regs.bit_regs_lengths)
             for i, reg in enumerate(regs.registers.bit_register_dict):
                 regs.registers.bit_register_dict[reg] = [
                     shot[::-1] for shot in transformed_counts[i]

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
@@ -147,7 +147,7 @@ def _transform_job_result(
     Dict[str, List[List[float]]],
     Dict[str, List[List[complex]]],
 ]:
-    if isinstance(output_registers, list):
+    if isinstance(output_registers, list) and isinstance(input_bit_circuits, list):
         _transform_job_result_list(memory, sim_type, result, output_registers, input_bit_circuits)
         final_output = RegistersWithLengths()
         for regs in output_registers:
@@ -167,7 +167,9 @@ def _transform_job_result(
                 else:
                     final_output.registers.complex_register_dict[key] = value_complexes
         return astuple(final_output.registers)
-    else:
+    elif isinstance(output_registers, RegistersWithLengths) and (
+        isinstance(input_bit_circuits, Circuit) or input_bit_circuits is None
+    ):
         _transform_job_result_single(
             memory,
             sim_type,
@@ -177,3 +179,5 @@ def _transform_job_result(
             res_index,
         )
         return astuple(output_registers.registers)
+    else:
+        raise ValueError("Invalid input for output_registers and/or input_bit_circuits.")

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/post_processing.py
@@ -92,9 +92,7 @@ def _transform_job_result_single(
             ]
         if input_bit_circuit:
             for input_bit_op in input_bit_circuit:
-                for bit_result in output_register.registers.bit_register_dict[
-                    input_bit_op.name()
-                ]:
+                for bit_result in output_register.registers.bit_register_dict[input_bit_op.name()]:
                     bit_result[input_bit_op.index()] = input_bit_op.value()
     elif sim_type == "statevector":
         vector = list(np.asarray(result.data(res_index)["statevector"]).flatten())
@@ -123,9 +121,7 @@ def _transform_job_result_list(
                 ]
             if input_bit_circuit:
                 for input_bit_op in input_bit_circuit:
-                    for bit_result in regs.registers.bit_register_dict[
-                        input_bit_op.name()
-                    ]:
+                    for bit_result in regs.registers.bit_register_dict[input_bit_op.name()]:
                         bit_result[input_bit_op.index()] = input_bit_op.value()
     elif sim_type == "statevector":
         for i, regs in enumerate(output_registers):

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/queued_results.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/queued_results.py
@@ -164,7 +164,7 @@ class QueuedCircuitRun:
                     complex_regs_lengths=self._registers_info[2],
                 )
                 self._qoqo_result = _transform_job_result(
-                    self._memory, self._sim_type, result, modeled, self._res_index
+                    self._memory, self._sim_type, result, modeled, None, self._res_index
                 )
                 return self._qoqo_result
             elif status == JobStatus.ERROR:

--- a/qoqo_qiskit/src/qoqo_qiskit/backend/queued_results.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/backend/queued_results.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from qiskit.providers import Job, JobStatus
 from qiskit_ibm_runtime import QiskitRuntimeService
-from qoqo import measurements
+from qoqo import measurements  # type:ignore
 
 from ..models import Registers, RegistersWithLengths
 from .post_processing import _transform_job_result
@@ -34,6 +34,8 @@ class QueuedCircuitRun:
         memory: bool,
         sim_type: str,
         registers_info: Tuple[
+            Dict[str, int],
+            Dict[str, int],
             Dict[str, int],
             Dict[str, List[List[bool]]],
             Dict[str, List[List[float]]],
@@ -58,6 +60,8 @@ class QueuedCircuitRun:
         self._memory: bool = memory
         self._sim_type: str = sim_type
         self._registers_info: Tuple[
+            Dict[str, int],
+            Dict[str, int],
             Dict[str, int],
             Dict[str, List[List[bool]]],
             Dict[str, List[List[float]]],
@@ -151,11 +155,13 @@ class QueuedCircuitRun:
                 result = self._job.result()
                 modeled = RegistersWithLengths(
                     Registers(
-                        bit_register_dict=self._registers_info[1],
-                        float_register_dict=self._registers_info[2],
-                        complex_register_dict=self._registers_info[3],
+                        bit_register_dict=self._registers_info[3],
+                        float_register_dict=self._registers_info[4],
+                        complex_register_dict=self._registers_info[5],
                     ),
-                    clas_regs_lengths=self._registers_info[0],
+                    bit_regs_lengths=self._registers_info[0],
+                    float_regs_lengths=self._registers_info[1],
+                    complex_regs_lengths=self._registers_info[2],
                 )
                 self._qoqo_result = _transform_job_result(
                     self._memory, self._sim_type, result, modeled, self._res_index

--- a/qoqo_qiskit/src/qoqo_qiskit/models.py
+++ b/qoqo_qiskit/src/qoqo_qiskit/models.py
@@ -37,18 +37,22 @@ class RegistersWithLengths:
     The registers are used to store classical information during the execution of a
     roqoqo circuit and to provide a unified output interface for the different backends.
 
-    In addition, a dictionary containing the lengths of any DefinitionBit register (indexed
+    In addition, a dictionary containing the lengths of any register (indexed
     by its name) is also provided.
 
     Defined by three dictionaries, representing bit, float and complex registers.
     """
 
     registers: Registers = field(default_factory=Registers)
-    clas_regs_lengths: Dict[str, int] = field(default_factory=dict)
+    bit_regs_lengths: Dict[str, int] = field(default_factory=dict)
+    float_regs_lengths: Dict[str, int] = field(default_factory=dict)
+    complex_regs_lengths: Dict[str, int] = field(default_factory=dict)
 
     def to_flat_tuple(
         self,
     ) -> Tuple[
+        Dict[str, int],
+        Dict[str, int],
         Dict[str, int],
         Dict[str, List[List[bool]]],
         Dict[str, List[List[float]]],
@@ -56,4 +60,9 @@ class RegistersWithLengths:
     ]:
         """Flattens the internal data into a single tuple."""
         internal_regs = astuple(self.registers)
-        return (self.clas_regs_lengths, *internal_regs)
+        return (
+            self.bit_regs_lengths,
+            self.float_regs_lengths,
+            self.complex_regs_lengths,
+            *internal_regs,
+        )

--- a/qoqo_qiskit/tests/backend/__init__.py
+++ b/qoqo_qiskit/tests/backend/__init__.py
@@ -11,4 +11,4 @@
 # the License.
 """Test folder for qoqo_qiskit: backend module."""
 
-from tests.backend import test_backend, test_queued_results
+from tests.backend import test_backend, test_queued_results, test_input_bit

--- a/qoqo_qiskit/tests/backend/test_backend.py
+++ b/qoqo_qiskit/tests/backend/test_backend.py
@@ -18,7 +18,7 @@ from typing import Any, List
 import pytest
 from qiskit_aer import AerSimulator
 from qoqo import Circuit, QuantumProgram
-from qoqo import operations as ops
+from qoqo import operations as ops  # type:ignore
 from qoqo.measurements import (  # type:ignore
     ClassicalRegister,
     PauliZProduct,

--- a/qoqo_qiskit/tests/backend/test_backend.py
+++ b/qoqo_qiskit/tests/backend/test_backend.py
@@ -550,13 +550,13 @@ def test_memory() -> None:
 
 def test_split() -> None:
     """Test post_processing._split method."""
-    clas_regs = {}
-    clas_regs["ro"] = 1
-    clas_regs["ri"] = 2
+    bit_regs = {}
+    bit_regs["ro"] = 1
+    bit_regs["ri"] = 2
     shot_result_ws = "01 1"
     shot_result_no_ws = "011"
 
-    assert _split(shot_result_ws, clas_regs) == _split(shot_result_no_ws, clas_regs)
+    assert _split(shot_result_ws, bit_regs) == _split(shot_result_no_ws, bit_regs)
 
 
 def test_overwrite() -> None:
@@ -687,7 +687,7 @@ def test_run_circuit_queued(memory: bool) -> None:
     assert qcr._memory == memory
     assert qcr._sim_type == "automatic"
     assert "ro" in qcr._registers_info[0]
-    assert "ro" in qcr._registers_info[1]
+    assert "ro" in qcr._registers_info[3]
 
 
 @pytest.mark.parametrize("memory", [True, False])
@@ -714,9 +714,9 @@ def test_run_circuit_list_queued(memory: bool) -> None:
     assert qcrs[0]._memory == qcrs[1]._memory == memory
     assert qcrs[0]._sim_type == qcrs[1]._sim_type == "automatic"
     assert "ro" in qcrs[0]._registers_info[0]
-    assert "ro" in qcrs[0]._registers_info[1]
+    assert "ro" in qcrs[0]._registers_info[3]
     assert "ri" in qcrs[1]._registers_info[0]
-    assert "ri" in qcrs[1]._registers_info[1]
+    assert "ri" in qcrs[1]._registers_info[3]
 
     time.sleep(1)
 

--- a/qoqo_qiskit/tests/backend/test_input_bit.py
+++ b/qoqo_qiskit/tests/backend/test_input_bit.py
@@ -1,0 +1,163 @@
+# Copyright © 2024 HQS Quantum Simulations GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+"""Test running local operation with qasm backend."""
+from qoqo_qiskit import QoqoQiskitBackend
+from qoqo import Circuit, QuantumProgram
+from qoqo.measurements import ClassicalRegister, PauliZProductInput, PauliZProduct  # type:ignore
+from qoqo import operations as ops  # type:ignore
+import pytest
+import sys
+
+list_of_operations = [
+    [ops.PauliX(1), ops.PauliX(0), ops.PauliZ(2), ops.PauliX(3), ops.PauliY(4)],
+    [
+        ops.Hadamard(0),
+        ops.CNOT(0, 1),
+        ops.CNOT(1, 2),
+        ops.CNOT(2, 3),
+        ops.CNOT(3, 4),
+    ],
+    [ops.RotateX(0, 0.23), ops.RotateY(1, 0.12), ops.RotateZ(2, 0.34)],
+]
+
+
+def test_running_with_input_bit() -> None:
+    """Test running simple circuit with InputBit."""
+    circuit = Circuit()
+    circuit += ops.DefinitionBit("ro", 2, True)
+    circuit += ops.InputBit("ro", 1, True)
+    circuit += ops.PauliX(0)
+    # circuit += ops.PragmaRepeatedMeasurement("ro", 2)
+    circuit += ops.MeasureQubit(0, "ro", 0)
+    circuit += ops.MeasureQubit(1, "ro", 1)
+    circuit += ops.PragmaSetNumberOfMeasurements(2, "ro")
+
+    backend = QoqoQiskitBackend()
+    (bit_res, _, _) = backend.run_circuit(circuit)
+    assert "ro" in bit_res.keys()
+    registers = bit_res["ro"]
+
+    assert len(registers) == 2
+    assert len(registers[0]) == 2
+    assert registers[0] == [True, True]
+
+    circuit = Circuit()
+    circuit += ops.DefinitionBit("ro", 3, True)
+    circuit += ops.InputBit("ro", 2, True)
+    circuit += ops.MeasureQubit(0, "ro", 0)
+    circuit += ops.MeasureQubit(1, "ro", 1)
+    circuit += ops.PragmaSetNumberOfMeasurements(2, "ro")
+
+    backend = QoqoQiskitBackend()
+    (bit_res, _, _) = backend.run_circuit(circuit)
+    assert "ro" in bit_res.keys()
+    registers = bit_res["ro"]
+
+    assert len(registers) == 2
+    assert len(registers[0]) == 3
+    assert registers[0] == [False, False, True]
+    assert registers[1] == [False, False, True]
+
+
+def test_running_with_input_bit_lists() -> None:
+    """Test running lists of circuits with InputBit."""
+    circuit_0 = Circuit()
+    circuit_0 += ops.DefinitionBit("ro", 2, True)
+    circuit_0 += ops.InputBit("ro", 1, True)
+    circuit_0 += ops.PauliX(0)
+    circuit_0 += ops.MeasureQubit(0, "ro", 0)
+    circuit_0 += ops.MeasureQubit(1, "ro", 1)
+    circuit_0 += ops.PragmaSetNumberOfMeasurements(5, "ro")
+
+    circuit_1 = Circuit()
+    circuit_1 += ops.DefinitionBit("ri", 3, True)
+    circuit_1 += ops.InputBit("ri", 2, True)
+    circuit_1 += ops.InputBit("ri", 1, True)
+    circuit_1 += ops.MeasureQubit(0, "ri", 0)
+    circuit_1 += ops.MeasureQubit(1, "ri", 1)
+    circuit_1 += ops.PragmaSetNumberOfMeasurements(5, "ri")
+
+    backend = QoqoQiskitBackend()
+    (bit_res, _, _) = backend.run_circuit_list([circuit_0, circuit_1])
+    assert "ro" in bit_res.keys()
+    assert "ri" in bit_res.keys()
+    registers_ro = bit_res["ro"]
+    registers_ri = bit_res["ri"]
+
+    assert len(registers_ro) == 5
+    assert len(registers_ri) == 5
+    assert [len(res) == 2 for res in registers_ro]
+    assert [len(res) == 3 for res in registers_ri]
+    assert registers_ro[0] == [True, True]
+    assert registers_ri[0] == [False, True, True]
+
+
+def test_quantum_program():
+    backend = QoqoQiskitBackend()
+
+    circuit = Circuit()
+    circuit += ops.DefinitionBit("ro", 2, True)
+    circuit += ops.InputBit("ro", 1, True)
+    circuit += ops.PauliX(0)
+    circuit += ops.RotateZ(0, "angle_0")
+    circuit += ops.MeasureQubit(0, "ro", 0)
+    circuit += ops.MeasureQubit(1, "ro", 1)
+    circuit += ops.PragmaSetNumberOfMeasurements(2, "ro")
+
+    measurement_input = PauliZProductInput(1, False)
+    z_basis_index = measurement_input.add_pauliz_product(
+        "ro",
+        [
+            0,
+        ],
+    )
+    measurement_input.add_linear_exp_val(
+        "<H>",
+        {z_basis_index: 0.2},
+    )
+
+    measurement = PauliZProduct(
+        constant_circuit=None,
+        circuits=[circuit],
+        input=measurement_input,
+    )
+
+    program = QuantumProgram(
+        measurement=measurement,
+        input_parameter_names=["angle_0"],
+    )
+
+    res = backend.run_program(program=program, params_values=[[1], [2], [3]])
+
+    assert len(res) == 3
+    for el in res:
+        assert float(el["<H>"])
+
+    res = backend.run_program(program=program, params_values=[1])
+
+    assert float(res["<H>"])
+
+    measurement = ClassicalRegister(constant_circuit=None, circuits=[circuit])
+
+    program = QuantumProgram(measurement=measurement, input_parameter_names=["angle_0"])
+
+    res = backend.run_program(program=program, params_values=[[0], [1], [2]])
+
+    assert len(res) == 3
+
+    res = backend.run_program(program=program, params_values=[0])
+
+    assert "ro" in res[0].keys()
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/qoqo_qiskit/tests/backend/test_queued_results.py
+++ b/qoqo_qiskit/tests/backend/test_queued_results.py
@@ -34,6 +34,8 @@ def _mocked_run(
     str,
     Tuple[
         Dict[str, int],
+        Dict[str, int],
+        Dict[str, int],
         Dict[str, List[List[bool]]],
         Dict[str, List[List[float]]],
         Dict[str, List[List[complex]]],

--- a/qoqo_qiskit/tests/backend/test_queued_results.py
+++ b/qoqo_qiskit/tests/backend/test_queued_results.py
@@ -139,9 +139,7 @@ def test_poll_result() -> None:
         registers_info=run_1[2],
     )
 
-    measurement = ClassicalRegister(
-        constant_circuit=None, circuits=[run_0[3], run_1[3]]
-    )
+    measurement = ClassicalRegister(constant_circuit=None, circuits=[run_0[3], run_1[3]])
     qpr = QueuedProgramRun(
         measurement=measurement,
         queued_circuits=[qcr_0, qcr_1],
@@ -176,9 +174,7 @@ def test_overwrite() -> None:
         registers_info=run_1[2],
     )
 
-    measurement = ClassicalRegister(
-        constant_circuit=None, circuits=[run_0[3], run_1[3]]
-    )
+    measurement = ClassicalRegister(constant_circuit=None, circuits=[run_0[3], run_1[3]])
     qpr = QueuedProgramRun(
         measurement=measurement,
         queued_circuits=[qcr_0, qcr_1],

--- a/qoqo_qiskit/tests/backend/test_queued_results.py
+++ b/qoqo_qiskit/tests/backend/test_queued_results.py
@@ -20,10 +20,9 @@ from typing import Dict, List, Tuple
 import pytest
 from qiskit.providers import Job
 from qoqo import Circuit
-from qoqo import operations as ops
+from qoqo import operations as ops  # type:ignore
 from qoqo.measurements import ClassicalRegister  # type:ignore
 from qoqo_qiskit.backend import QoqoQiskitBackend, QueuedCircuitRun, QueuedProgramRun
-from qoqo_qiskit.models import RegistersWithLengths
 
 
 def _mocked_run(

--- a/qoqo_qiskit/tests/backend/test_queued_results.py
+++ b/qoqo_qiskit/tests/backend/test_queued_results.py
@@ -56,7 +56,7 @@ def _mocked_run(
 
     backend = QoqoQiskitBackend(memory=memory)
 
-    (job, sim_type, output_registers) = backend._run_circuit(circuit)
+    (job, sim_type, output_registers, _input_bit_circuit) = backend._run_circuit(circuit)
 
     return (job, sim_type, output_registers.to_flat_tuple(), circuit)
 

--- a/qoqo_qiskit/tests/transpiler_helper/test_transpiler_helper.py
+++ b/qoqo_qiskit/tests/transpiler_helper/test_transpiler_helper.py
@@ -39,9 +39,7 @@ def test_basic_circuit_basic_gates() -> None:
     circuit_res += ops.SqrtPauliX(0)
     circuit_res += ops.SqrtPauliX(0)
 
-    transpiled_circuit = transpile_with_qiskit(
-        circuit, [{"basis_gates": ["sx", "rz", "cz"]}]
-    )
+    transpiled_circuit = transpile_with_qiskit(circuit, [{"basis_gates": ["sx", "rz", "cz"]}])
     assert transpiled_circuit == circuit_res
 
 
@@ -59,9 +57,7 @@ def test_medium_circuit_basic_gates() -> None:
     circuit_res += ops.SqrtPauliX(1)
     circuit_res += ops.RotateZ(1, 1.5707963267948966)
 
-    transpiled_circuit = transpile_with_qiskit(
-        circuit, [{"basis_gates": ["sx", "rz", "cz"]}]
-    )
+    transpiled_circuit = transpile_with_qiskit(circuit, [{"basis_gates": ["sx", "rz", "cz"]}])
 
     assert transpiled_circuit == circuit_res
 
@@ -167,19 +163,14 @@ def test_multiple_circuits_backend() -> None:
     circuit_res_2 += ops.RotateZ(1, 1.5707963267948966)
 
     backend = FakeManilaV2()
-    transpiled_circuits = transpile_with_qiskit(
-        [circuit_1, circuit_2], [{"backend": backend}]
-    )
+    transpiled_circuits = transpile_with_qiskit([circuit_1, circuit_2], [{"backend": backend}])
 
     transpiled_circuit_dag = CircuitDag()
     circuit_res_dag = CircuitDag()
     transpiled_circuit_dag = transpiled_circuit_dag.from_circuit(transpiled_circuits[1])
     circuit_res_dag = circuit_res_dag.from_circuit(circuit_res_2)
 
-    assert (
-        transpiled_circuits[0] == circuit_res_1
-        and transpiled_circuit_dag == circuit_res_dag
-    )
+    assert transpiled_circuits[0] == circuit_res_1 and transpiled_circuit_dag == circuit_res_dag
 
 
 def assert_quantum_program_equal(
@@ -194,15 +185,9 @@ def assert_quantum_program_equal(
     Raises:
         AssertionError: if the quantum programs are not equal
     """
-    assert (
-        quantum_program_1.input_parameter_names()
-        == quantum_program2.input_parameter_names()
-    )
+    assert quantum_program_1.input_parameter_names() == quantum_program2.input_parameter_names()
     if not isinstance(quantum_program_1.measurement(), ClassicalRegister):
-        assert (
-            quantum_program_1.measurement().input()
-            == quantum_program2.measurement().input()
-        )
+        assert quantum_program_1.measurement().input() == quantum_program2.measurement().input()
     assert (
         quantum_program_1.measurement().constant_circuit()
         == quantum_program2.measurement().constant_circuit()
@@ -240,18 +225,12 @@ def test_basic_program_basic_gates() -> None:
     circuit_res_2 += ops.SqrtPauliX(1)
     circuit_res_2 += ops.RotateZ(1, 1.5707963267948966)
 
-    measurement = ClassicalRegister(
-        constant_circuit=None, circuits=[circuit_1, circuit_2]
-    )
+    measurement = ClassicalRegister(constant_circuit=None, circuits=[circuit_1, circuit_2])
     measurement_res = ClassicalRegister(
         constant_circuit=None, circuits=[circuit_res_1, circuit_res_2]
     )
-    quantum_program = QuantumProgram(
-        measurement=measurement, input_parameter_names=["x"]
-    )
-    quantum_program_res = QuantumProgram(
-        measurement=measurement_res, input_parameter_names=["x"]
-    )
+    quantum_program = QuantumProgram(measurement=measurement, input_parameter_names=["x"])
+    quantum_program_res = QuantumProgram(measurement=measurement_res, input_parameter_names=["x"])
 
     transpiled_program = transpile_program_with_qiskit(
         quantum_program, [{"basis_gates": ["sx", "rz", "cz"]}]
@@ -301,12 +280,8 @@ def test_program_with_constant_circuit_basic_gates() -> None:
         circuits=[circuit_res_1, circuit_res_2],
         input=measurement_input,
     )
-    quantum_program = QuantumProgram(
-        measurement=measurement, input_parameter_names=["x"]
-    )
-    quantum_program_res = QuantumProgram(
-        measurement=measurement_res, input_parameter_names=["x"]
-    )
+    quantum_program = QuantumProgram(measurement=measurement, input_parameter_names=["x"])
+    quantum_program_res = QuantumProgram(measurement=measurement_res, input_parameter_names=["x"])
 
     transpiled_program = transpile_program_with_qiskit(
         quantum_program, [{"basis_gates": ["sx", "rz", "cz"]}]
@@ -360,17 +335,11 @@ def test_quantum_program_backend() -> None:
         circuits=[circuit_res_1, circuit_res_2, circuit_res_3],
         input=measurement_input,
     )
-    quantum_program = QuantumProgram(
-        measurement=measurement, input_parameter_names=["x"]
-    )
-    quantum_program_res = QuantumProgram(
-        measurement=measurement_res, input_parameter_names=["x"]
-    )
+    quantum_program = QuantumProgram(measurement=measurement, input_parameter_names=["x"])
+    quantum_program_res = QuantumProgram(measurement=measurement_res, input_parameter_names=["x"])
 
     backend = FakeManilaV2()
-    transpiled_program = transpile_program_with_qiskit(
-        quantum_program, [{"backend": backend}]
-    )
+    transpiled_program = transpile_program_with_qiskit(quantum_program, [{"backend": backend}])
 
     assert_quantum_program_equal(transpiled_program, quantum_program_res)
 
@@ -433,16 +402,10 @@ def test_quantum_program_with_constant_circuit_backend() -> None:
         circuits=[circuit_res_1, circuit_res_2, circuit_res_3],
         input=measurement_input,
     )
-    quantum_program = QuantumProgram(
-        measurement=measurement, input_parameter_names=["x"]
-    )
-    quantum_program_res = QuantumProgram(
-        measurement=measurement_res, input_parameter_names=["x"]
-    )
+    quantum_program = QuantumProgram(measurement=measurement, input_parameter_names=["x"])
+    quantum_program_res = QuantumProgram(measurement=measurement_res, input_parameter_names=["x"])
 
     backend = FakeManilaV2()
-    transpiled_program = transpile_program_with_qiskit(
-        quantum_program, [{"backend": backend}]
-    )
+    transpiled_program = transpile_program_with_qiskit(quantum_program, [{"backend": backend}])
 
     assert_quantum_program_equal(transpiled_program, quantum_program_res)

--- a/qoqo_qiskit_devices/Cargo.toml
+++ b/qoqo_qiskit_devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qiskit_devices"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/qoqo_qiskit_devices/pyproject.toml
+++ b/qoqo_qiskit_devices/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qiskit_devices"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
   'qoqo_calculator_pyo3>=1.2,<1.3',
   'qoqo>=1.15,<1.16',

--- a/qoqo_qiskit_devices/qoqo_qiskit_devices/DEPENDENCIES
+++ b/qoqo_qiskit_devices/qoqo_qiskit_devices/DEPENDENCIES
@@ -794,7 +794,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-bytemuck 1.17.1
+bytemuck 1.18.0
 https://github.com/Lokathor/bytemuck
 by Lokathor <zefria@gmail.com>
 A crate for mucking around with piles of bytes.
@@ -10338,7 +10338,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_qiskit_devices 0.8.0
+qoqo_qiskit_devices 0.8.1
 https://github.com/HQSquantumsimulations/qoqo_qiskit
 by HQS Quantum Simulations <info@quantumsimulations.de>
 IBM's Qiskit devices interface for qoqo python quantum computing toolkit
@@ -11927,7 +11927,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-redox_syscall 0.5.3
+redox_syscall 0.5.4
 https://gitlab.redox-os.org/redox-os/syscall
 by Jeremy Soller <jackpot51@gmail.com>
 A Rust library to access raw Redox system calls
@@ -13108,7 +13108,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo_qiskit_devices 0.8.0
+roqoqo_qiskit_devices 0.8.1
 https://github.com/HQSquantumsimulations/qoqo_qiskit
 by HQS Quantum Simulations <info@quantumsimulations.de>
 IBM's Qiskit devices interface for roqoqo rust quantum computing toolkit
@@ -14183,7 +14183,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde 1.0.209
+serde 1.0.210
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -14397,7 +14397,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.209
+serde_derive 1.0.210
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -17631,7 +17631,7 @@ LICENSE:
 MIT OR Apache-2.0
 
 ====================================================
-unicode-ident 1.0.12
+unicode-ident 1.0.13
 https://github.com/dtolnay/unicode-ident
 by David Tolnay <dtolnay@gmail.com>
 Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31

--- a/roqoqo_qiskit_devices/Cargo.toml
+++ b/roqoqo_qiskit_devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo_qiskit_devices"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
* Fixed `.run_program()` allowing it to run with a single list of parameters
* Fixed support for `InputBit` operation by keeping track of it and correct the circuit result in post-process

Same fix as https://github.com/HQSquantumsimulations/qoqo-for-braket/pull/31